### PR TITLE
Remove the need for unsafe code

### DIFF
--- a/fNbt/DoubleAndULongUnion.cs
+++ b/fNbt/DoubleAndULongUnion.cs
@@ -1,0 +1,9 @@
+using System.Runtime.InteropServices;
+
+[StructLayout(LayoutKind.Explicit)]
+public struct DoubleAndULongUnion {
+	[FieldOffset(0)]
+	public ulong UInt64Bits;
+	[FieldOffset(0)]
+	public double DoubleValue;
+}

--- a/fNbt/FloatAndUIntUnion.cs
+++ b/fNbt/FloatAndUIntUnion.cs
@@ -1,0 +1,9 @@
+using System.Runtime.InteropServices;
+
+[StructLayout(LayoutKind.Explicit)]
+public struct FloatAndUIntUnion {
+	[FieldOffset(0)]
+	public uint UInt32Bits;
+	[FieldOffset(0)]
+	public float FloatValue;
+}


### PR DESCRIPTION
Unsafe code was only used in three places in the NbtBinaryWriter class: once each to cast floats to uint bits and doubles to ulong bits, and once to use [this method](https://msdn.microsoft.com/en-us/library/wa05d9tx.aspx). I have changed the casting to make use of struct member overlap, and there is [an almost identical method](https://msdn.microsoft.com/en-us/library/5zxk59x5.aspx) that uses safe code.

These changes should make compiling easier (they did for me).
